### PR TITLE
Script pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,27 @@ Get a list of the PRs that got closed today, and email it to the POs (_this last
 ```
 PO_TOKEN=... bundle exec ruby todays-prs.rb
 ```
+
+
+## 'release-pdf.sh'
+
+# pre-steps
+//get ruby
+curl -L https://get.rvm.io | bash -s stable --auto-dotfiles --autolibs=enable --ruby
+rvm install "ruby-2.3.1"
+rvm use 2.3.1
+gem install bundler
+
+//get other dependencies
+*install node*
+sudo npm install mdpdf -g
+sudo npm install -g phantomjs-prebuilt --unsafe-perm=true  --allow-root
+
+
+chmod +x  release-pdf.sh
+# usage 
+./release-pdf.sh <release version> <pdf name> 
+
+	eg. ./release-pdf.sh "2.42.0" "iOS-2.42.0--RC-1--BUILD-15065--Release-Notes" 
+
+	the pdf name contains the release version, cadidate version and build version

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A set of scripts to extract information from GitHub and JIRA that POs care about, without wasting dev time.
 
-## `todays-prs.rb`
+# `todays-prs.rb`
 
 Get a list of the PRs that got closed today, and email it to the POs (_this last part is still TODO_)
 
@@ -11,25 +11,26 @@ PO_TOKEN=... bundle exec ruby todays-prs.rb
 ```
 
 
-## 'release-pdf.sh'
+# `release-pdf.sh`
 
-# pre-steps
-//get ruby
+## pre-steps
+get ruby, node and other dependencies
+```sh
 curl -L https://get.rvm.io | bash -s stable --auto-dotfiles --autolibs=enable --ruby
 rvm install "ruby-2.3.1"
 rvm use 2.3.1
 gem install bundler
 
-//get other dependencies
-*install node*
+#install node https://nodejs.org/en/download
 sudo npm install mdpdf -g
 sudo npm install -g phantomjs-prebuilt --unsafe-perm=true  --allow-root
 
-
 chmod +x  release-pdf.sh
-# usage 
-./release-pdf.sh <release version> <pdf name> 
+```
 
-	eg. ./release-pdf.sh "2.42.0" "iOS-2.42.0--RC-1--BUILD-15065--Release-Notes" 
+## usage 
+PO_TOKEN=<private po token> ./release-pdf.sh <release version> <pdf name> 
 
-	the pdf name contains the release version, cadidate version and build version
+eg. ```PO_TOKEN=abc123 ./release-pdf.sh "2.42.0" "iOS-2.42.0--RC-1--BUILD-15065--Release-Notes"``` 
+
+the pdf name contains the release version, cadidate version and build version

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ chmod +x  release-pdf.sh
 ```
 
 ## usage 
-PO_TOKEN=<private po token> ./release-pdf.sh <release version> <pdf name> 
+PO_TOKEN=<private po token> ./release-pdf.sh <i||a> <release version> 
 
-eg. ```PO_TOKEN=abc123 ./release-pdf.sh "2.42.0" "iOS-2.42.0--RC-1--BUILD-15065--Release-Notes"``` 
+eg. ```PO_TOKEN=abc123 ./release-pdf.sh i 2.42.0``` 
 
-the pdf name contains the release version, cadidate version and build version
+the first arg must be "i" for iOS or "a" for Android

--- a/release-notes.rb
+++ b/release-notes.rb
@@ -2,16 +2,17 @@ require 'octokit'
 
 usage = <<USAGE
 \n\nUsage:
-\tPO_TOKEN=1234 ruby release-notes.rb release_number'
+\tPO_TOKEN=1234 ruby release-notes.rb release_number repo'
 USAGE
 
 release = ARGV[0]
+repo = ARGV[1]
 
 raise usage if release.nil?
+raise usage if repo.nil?
 raise usage if ENV['PO_TOKEN'].nil?
 
 # TODO: make these values configurable via ARGV or something
-repo = 'iflix-letsplay/apple-ios'
 jira_base_url = 'https://teamiflix.atlassian.net/browse'
 
 # Init an Octokit client with a token with access to the repo you want to

--- a/release-pdf.sh
+++ b/release-pdf.sh
@@ -3,9 +3,22 @@ set -e
 if [ -z "$PO_TOKEN" ]; then echo "PO_TOKEN is unset"; fi
 
 if [ $# -ne 2 ] || [  -z "$PO_TOKEN" ]; then
-    echo 'usage: PO_TOKEN=<private po token> ./release-pdf.sh <release version> <pdf name>'
+    echo 'usage: PO_TOKEN=<private po token> ./release-pdf.sh <i||a> <release version>'
     exit 1
 fi
-bundle install && bundle exec ruby release-notes.rb $1 > $2.md
-mdpdf $2.md
-rm $2.md
+if [ "$1" = "a" ]; then
+	FILENAME="Android"
+	REPO='iflix-letsplay/iflix-android'
+elif [ "$1" = "i" ]; then
+	FILENAME="iOS"
+	REPO='iflix-letsplay/apple-ios'
+else
+	echo 'first arg must be "i" for iOS or "a" for Android'	
+	exit 1
+fi
+
+FILENAME=$FILENAME-$2--Release-Notes
+echo $FILENAME
+bundle install && bundle exec ruby release-notes.rb $2 $REPO> $FILENAME.md
+mdpdf $FILENAME.md
+rm $FILENAME.md

--- a/release-pdf.sh
+++ b/release-pdf.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ $# -ne 2 ]; then
+    echo 'usage: ./release-pdf.sh <release version> <pdf name>'
+    exit 1
+fi
+bundle install && PO_TOKEN=cea9a05c311ed1996b973477f01773f847047f37 bundle exec ruby release-notes.rb $1 > $2.md
+mdpdf $2.md
+rm $2.md

--- a/release-pdf.sh
+++ b/release-pdf.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-if [ $# -ne 2 ]; then
-    echo 'usage: ./release-pdf.sh <release version> <pdf name>'
+set -e
+if [ -z "$PO_TOKEN" ]; then echo "PO_TOKEN is unset"; fi
+
+if [ $# -ne 2 ] || [  -z "$PO_TOKEN" ]; then
+    echo 'usage: PO_TOKEN=<private po token> ./release-pdf.sh <release version> <pdf name>'
     exit 1
 fi
-bundle install && PO_TOKEN=cea9a05c311ed1996b973477f01773f847047f37 bundle exec ruby release-notes.rb $1 > $2.md
+bundle install && bundle exec ruby release-notes.rb $1 > $2.md
 mdpdf $2.md
 rm $2.md


### PR DESCRIPTION
update scripts for android use.
I am assuming that we dont need to include candidate number or build version in the name as it was not in previous Android release notes, it was however, included in past iOS release notes. we can discuss this discrepancy if required.